### PR TITLE
Use network module_utils from netcommon collections for OS10 collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# The Ansible collection for Dell EMC PowerSwitch platforms running SmartFabric OS10
+# The Ansible Network collection for Dell EMC PowerSwitch platforms running SmartFabric OS10
 
 ## Collection contents
-The OS10 Ansible collection includes the Ansible modules, plugins and roles required to work on a Dell EMC SmartFabric OS10 PowerSwitch. It also includes sample playbooks and documents that illustrate how the collection can be used.
+The Ansible network collection for Dell EMC SmartFabric OS10 includes the Ansible modules, plugins and roles required to work on Dell EMC PowerSwitch platforms running SmartFabric OS10. It also includes sample playbooks and documents that illustrate how the collection can be used.
 
 ### Ansible modules
-The following Ansible modules are part of the OS10 collection:
+The following modules are part of this collection:
 
 - **os10_command.py** — Run commands on remote devices running Dell EMC SmartFabric OS10
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,7 +3,7 @@ authors:
 - Senthil Ganesan Ganesan <Senthil_Kumar_Ganesa@Dell.com>
 - Shreeja R <Shreeja_R@Dell.com>
 dependencies:
-  ansible.netcommon: '>=0.0.1'
+  ansible.netcommon: '>=0.0.2'
 description: Ansible network collections for Dell EMC PowerSwitch platforms running Dell EMC SmartFabric OS10
 license_file: LICENSE
 name: os10

--- a/plugins/action/os10.py
+++ b/plugins/action/os10.py
@@ -28,8 +28,8 @@ import copy
 from ansible import constants as C
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection
-from ansible.plugins.action.network import ActionModule as ActionNetworkModule
-from ansible.module_utils.network.common.utils import load_provider
+from ansible_collections.ansible.netcommon.plugins.action.network import ActionModule as ActionNetworkModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import load_provider
 from ansible_collections.dellemc.os10.plugins.module_utils.network.os10 import os10_provider_spec
 from ansible.utils.display import Display
 

--- a/plugins/cliconf/os10.py
+++ b/plugins/cliconf/os10.py
@@ -37,7 +37,7 @@ import json
 from itertools import chain
 
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.network.common.utils import to_list
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 from ansible.plugins.cliconf import CliconfBase, enable_mode
 
 class Cliconf(CliconfBase):

--- a/plugins/module_utils/network/os10.py
+++ b/plugins/module_utils/network/os10.py
@@ -35,7 +35,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.network.common.utils import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
-from ansible.module_utils.network.common.config import NetworkConfig, ConfigLine
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import NetworkConfig, ConfigLine
 
 _DEVICE_CONFIGS = {}
 

--- a/plugins/modules/os10_command.py
+++ b/plugins/modules/os10_command.py
@@ -131,8 +131,8 @@ import time
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.os10.plugins.module_utils.network.os10 import run_commands
 from ansible_collections.dellemc.os10.plugins.module_utils.network.os10 import os10_argument_spec, check_args
-from ansible.module_utils.network.common.utils import ComplexList
-from ansible.module_utils.network.common.parsing import Conditional
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import ComplexList
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.six import string_types
 
 def to_lines(stdout):

--- a/plugins/modules/os10_config.py
+++ b/plugins/modules/os10_config.py
@@ -204,7 +204,7 @@ from ansible_collections.dellemc.os10.plugins.module_utils.network.os10 import g
 from ansible_collections.dellemc.os10.plugins.module_utils.network.os10 import os10_argument_spec, check_args
 from ansible_collections.dellemc.os10.plugins.module_utils.network.os10 import load_config, run_commands
 from ansible_collections.dellemc.os10.plugins.module_utils.network.os10 import WARNING_PROMPTS_RE
-from ansible.module_utils.network.common.config import NetworkConfig, dumps
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import NetworkConfig, dumps
 
 
 


### PR DESCRIPTION
Some network utils are moved from core Ansible package to netcommon collection.
So, modifying the OS10 collections to import netcommon utils

