### PR TITLE
Modified to support v4 and v6 aggregare address with summary_only option

### DIFF
--- a/roles/os10_bgp/README.md
+++ b/roles/os10_bgp/README.md
@@ -37,6 +37,7 @@ Role variables
 | ``address_family_ipv4`` | dictionary | Configures IPv4 address family parameters (see ``address_family_ipv4.*``) | os10 |
 | ``address_family_ipv4.aggregate_addr`` | list | Configures IPv4 BGP aggregate entries (see ``aggregate_addr.*``) | os10 |
 | ``aggregate_addr.ip_and_mask`` | string | Configures the IPv4 BGP aggregate address | os10 |
+| ``address_family_ipv4.summary_only`` | boolean | Sets address to summary-only if true | dellos10 |
 | ``aggregate_addr.state`` | string: absent,present\* | Deletes an IPv4 BGP aggregate entry if set to absent   | os10 |
 | ``address_family_ipv4.dampening`` | dictionary | Configures route-flap dampening (see ``dampening.*``) | os10 |
 | ``dampening.value`` | dictionary | Configures dampening values (<half-life time> <start value to reuse> <start value to suppress> <max duration> format; default 15 750 2000 60) | os10 |
@@ -45,6 +46,7 @@ Role variables
 | ``address_family_ipv6`` | dictionary | Configures IPv6 address family parameters (see ``address_family_ipv6.*``) | os10 |
 | ``address_family_ipv6.aggregate_addr`` | list | Configures IPv6 BGP aggregate entries (see ``aggregate_addr.*``) | os10 |
 | ``aggregate_addr.ip_and_mask`` | string | Configures the IPv6 BGP aggregate address | os10 |
+| ``address_family_ipv6.summary_only`` | boolean | Sets address to summary-only if true | dellos10 |
 | ``aggregate_addr.state`` | string: absent,present\* | Deletes an IPv6 BGP aggregate entry if set to absent   | os10 |
 | ``address_family_ipv6.dampening`` | dictionary | Configures route-flap dampening (see ``dampening.*``) | os10 |
 | ``dampening.value`` | dictionary | Configures dampening values (<half-life time> <start value to reuse> <start value to suppress> <max duration> format; default 15 750 2000 60) | os10 |
@@ -215,10 +217,16 @@ When *os10_cfg_generate* is set to true, the variable generates the configuratio
           aggregate_address:
              - ip_and_mask: 1.1.1.1/16
                state: present
+               summary_only: true
           dampening:
             value: 15 750 2000 60
             route_map: qq
             state: present
+        address_family_ipv6:
+          aggregate_address:
+             - ip_and_mask: 2001:4898:5808:ffa0::/126
+               state: present
+               summary_only: true
         best_path:
            as_path: ignore
            as_path_state: present

--- a/roles/os10_bgp/README.md
+++ b/roles/os10_bgp/README.md
@@ -37,7 +37,7 @@ Role variables
 | ``address_family_ipv4`` | dictionary | Configures IPv4 address family parameters (see ``address_family_ipv4.*``) | os10 |
 | ``address_family_ipv4.aggregate_addr`` | list | Configures IPv4 BGP aggregate entries (see ``aggregate_addr.*``) | os10 |
 | ``aggregate_addr.ip_and_mask`` | string | Configures the IPv4 BGP aggregate address | os10 |
-| ``address_family_ipv4.summary_only`` | boolean | Sets address to summary-only if true | dellos10 |
+| ``address_family_ipv4.summary_only`` | boolean | Sets address to summary-only if true | os10 |
 | ``aggregate_addr.state`` | string: absent,present\* | Deletes an IPv4 BGP aggregate entry if set to absent   | os10 |
 | ``address_family_ipv4.dampening`` | dictionary | Configures route-flap dampening (see ``dampening.*``) | os10 |
 | ``dampening.value`` | dictionary | Configures dampening values (<half-life time> <start value to reuse> <start value to suppress> <max duration> format; default 15 750 2000 60) | os10 |
@@ -46,7 +46,7 @@ Role variables
 | ``address_family_ipv6`` | dictionary | Configures IPv6 address family parameters (see ``address_family_ipv6.*``) | os10 |
 | ``address_family_ipv6.aggregate_addr`` | list | Configures IPv6 BGP aggregate entries (see ``aggregate_addr.*``) | os10 |
 | ``aggregate_addr.ip_and_mask`` | string | Configures the IPv6 BGP aggregate address | os10 |
-| ``address_family_ipv6.summary_only`` | boolean | Sets address to summary-only if true | dellos10 |
+| ``address_family_ipv6.summary_only`` | boolean | Sets address to summary-only if true | os10 |
 | ``aggregate_addr.state`` | string: absent,present\* | Deletes an IPv6 BGP aggregate entry if set to absent   | os10 |
 | ``address_family_ipv6.dampening`` | dictionary | Configures route-flap dampening (see ``dampening.*``) | os10 |
 | ``dampening.value`` | dictionary | Configures dampening values (<half-life time> <start value to reuse> <start value to suppress> <max duration> format; default 15 750 2000 60) | os10 |
@@ -132,22 +132,22 @@ Role variables
 | ``bfd_all_neighbors.role``| string: active, passive | Configures BFD role | os10 |
 | ``bfd_all_neighbors.state`` |string: absent,present\*    | Deletes BFD for all neighbors if set to absent | os10 |
 | ``state`` |  string: absent,present\*    | Deletes the local router BGP instance if set to absent      | os10 |
-| ``vrf`` | dictionary | Enables VRF under BGP | dellos10 |
-| ``vrf.name`` | string (Required)| Configures VRF name | dellos10 |
-| ``vrf.router_id`` | string | Configures Router ID for VRF | dellos10 |
-| ``vrf.address_family`` | dictionary | Enables address familyaddress | dellos10 |
-| ``vrf.address_family.type`` | string (required): ipv4,ipv6 | Configures address type ipv4 or ipv6 | dellos10 |
-| ``vrf.redistribute`` | dictionary | Enables redistribute option | dellos10 |
+| ``vrf`` | dictionary | Enables VRF under BGP | os10 |
+| ``vrf.name`` | string (Required)| Configures VRF name | os10 |
+| ``vrf.router_id`` | string | Configures Router ID for VRF | os10 |
+| ``vrf.address_family`` | dictionary | Enables address familyaddress | os10 |
+| ``vrf.address_family.type`` | string (required): ipv4,ipv6 | Configures address type ipv4 or ipv6 | os10 |
+| ``vrf.redistribute`` | dictionary | Enables redistribute option | os10 |
 | ``vrf.redistribute.imported_bgp_vrf_name`` | string        | Configures the redistribute imported bgp vrf name | os10 |
-| ``vrf.redistribute.route_type`` | string (l2vpn, ospf, bgp, connected, imported_bgp) | Configure redistribute type | dellos10 |
-| ``vrf.redistribute.address_type`` | string (required): ipv4,ipv6 | Configures address type ipv4 or ipv6 | dellos10 |
-| ``vrf.redistribute.state `` | string (required) | Configures the state as present or absent | dellos10 |
-| ``vrf.neighbor`` | list | Configures IPv4 BGP neighbors under vrf | dellos10 |
-| ``vrf.neighbor.admin`` | string: up,down  | Configures the administrative state of the neighbor in vrf | dellos10 |
-| ``vrf.neighbor.type`` | string : ipv4,ipv6 | Specifies the BGP neighbor type under vrf  | dellos10 |
-| ``vrf.neighbor.ip`` | string | Configures the IP address of the BGP neighbor in vrf  | dellos10 |
-| ``vrf.neighbor.interface`` | string  | Configures the BGP neighbor interface in vrf | dellos10  |
-| ``vrf.neighbor.remote_asn`` | integer  | Configures the remote AS for the BGP peer in vrf | dellos10  |
+| ``vrf.redistribute.route_type`` | string (l2vpn, ospf, bgp, connected, imported_bgp) | Configure redistribute type | os10 |
+| ``vrf.redistribute.address_type`` | string (required): ipv4,ipv6 | Configures address type ipv4 or ipv6 | os10 |
+| ``vrf.redistribute.state `` | string (required) | Configures the state as present or absent | os10 |
+| ``vrf.neighbor`` | list | Configures IPv4 BGP neighbors under vrf | os10 |
+| ``vrf.neighbor.admin`` | string: up,down  | Configures the administrative state of the neighbor in vrf | os10 |
+| ``vrf.neighbor.type`` | string : ipv4,ipv6 | Specifies the BGP neighbor type under vrf  | os10 |
+| ``vrf.neighbor.ip`` | string | Configures the IP address of the BGP neighbor in vrf  | os10 |
+| ``vrf.neighbor.interface`` | string  | Configures the BGP neighbor interface in vrf | os10  |
+| ``vrf.neighbor.remote_asn`` | integer  | Configures the remote AS for the BGP peer in vrf | os10  |
 
 > **NOTE**: Asterisk (\*) denotes the default value if none is specified.
 

--- a/roles/os10_bgp/templates/os10_bgp.j2
+++ b/roles/os10_bgp/templates/os10_bgp.j2
@@ -23,10 +23,16 @@ os10_bgp:
       aggregate_address:
          - ip_and_mask: 1.1.1.1/16
            state: present
+           summary_only: true
       dampening:
         value: 15 750 2000 60
         route_map: qq
         state: present
+    address_family_ipv6:
+      aggregate_address:
+         - ip_and_mask: 2001:4898:5808:ffa0::/126
+           state: present
+           summary_only: true
     best_path:
        as_path: ignore
        as_path_state: present
@@ -304,7 +310,43 @@ router bgp {{ bgp_vars.asn }}
     {% if bgp_vars.address_family_ipv4 is defined and bgp_vars.address_family_ipv4 %}
       {% set af_vars = bgp_vars.address_family_ipv4 %}
  address-family ipv4 unicast
-    {% elif bgp_vars.address_family_ipv6 is defined and bgp_vars.address_family_ipv6 %}
+    {% endif %}
+    {% if af_vars is defined and af_vars %}
+      {% if af_vars.aggregate_address is defined and af_vars.aggregate_address %}
+        {% for addr in af_vars.aggregate_address %}
+          {% if addr.ip_and_mask is defined and addr.ip_and_mask %}
+            {% if addr.state is defined and addr.state == "absent" %}
+  no aggregate-address {{ addr.ip_and_mask }}
+            {% else %}
+              {% if addr.summary_only is defined and addr.summary_only %}
+  aggregate-address {{ addr.ip_and_mask }} summary-only
+              {% else %}
+  aggregate-address {{ addr.ip_and_mask }}
+              {% endif %}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+      {% if af_vars.dampening is defined and af_vars.dampening %}
+        {% if af_vars.dampening.state is defined and af_vars.dampening.state == "absent" %}
+  no dampening
+        {% else %}
+          {% if af_vars.dampening.value is defined and af_vars.dampening.value %}
+            {% if af_vars.dampening.route_map is defined and af_vars.dampening.route_map %}
+  dampening {{ af_vars.dampening.value }} route-map {{ af_vars.dampening.route_map }}
+            {% else %}
+  dampening {{ af_vars.dampening.value }}
+            {% endif %}
+          {% else %}
+            {% if af_vars.dampening.route_map is defined and af_vars.dampening.route_map %}
+  dampening 15 750 2000 60 route-map {{ af_vars.dampening.route_map }}
+            {% endif %}
+          {% endif %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+
+    {% if bgp_vars.address_family_ipv6 is defined and bgp_vars.address_family_ipv6 %}
       {% set af_vars = bgp_vars.address_family_ipv6 %}
  address-family ipv6 unicast
     {% endif %}
@@ -315,7 +357,11 @@ router bgp {{ bgp_vars.asn }}
             {% if addr.state is defined and addr.state == "absent" %}
   no aggregate-address {{ addr.ip_and_mask }}
             {% else %}
+              {% if addr.summary_only is defined and addr.summary_only %}
+  aggregate-address {{ addr.ip_and_mask }} summary-only
+              {% else %}
   aggregate-address {{ addr.ip_and_mask }}
+              {% endif %}
             {% endif %}
           {% endif %}
         {% endfor %}

--- a/roles/os10_bgp/tests/main.os10.yaml
+++ b/roles/os10_bgp/tests/main.os10.yaml
@@ -27,6 +27,11 @@ os10_bgp:
         value: 15 750 2000 60
         route_map: qq
         state: present
+    address_family_ipv6:
+      aggregate_address:
+         - ip_and_mask: 2001:4898:5808:ffa0::/126
+           state: present
+           summary_only: true
     best_path:
        as_path: ignore
        as_path_state: present


### PR DESCRIPTION
##### SUMMARY
-Modified to support both IPv4 and IPv6 Aggregate address commands
- Added support for summary-only option for Aggregate address commands

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
OS10 BGP role

