### PR TITLE
adding support for 'hardware l3 ipv6-extended-prefix'

### DIFF
--- a/roles/os10_system/README.md
+++ b/roles/os10_system/README.md
@@ -20,6 +20,7 @@ Role variables
 |------------|---------------------------|---------------------------------------------------------|-----------------------|
 | ``hostname`` | string | Configures a hostname to the device (no negate command) | os10 |
 | ``hardware_forwarding`` | string: scaled-l2,scaled-l3-routes,scaled-l3-hosts         | Configures hardware forwarding mode | os10 |
+  ``hardware_forwarding_ipv6_extended_prefix`` | string: 1024, 2048 or 3072 | Configures the maximum number of route entries for IPv6 extended prefix route| os10 |
 | ``hash_algo`` | dictionary | Configures hash algorithm commands (see ``hash_algo.*``) | os10 |
 | ``hash_algo.algo`` | list         | Configures hashing algorithm (see ``algo.*``)   | os10 |
 | ``algo.name`` | string (required)       | Configures the name of the hashing algorithm | os10 |

--- a/roles/os10_system/templates/os10_system.j2
+++ b/roles/os10_system/templates/os10_system.j2
@@ -37,6 +37,13 @@ os10_system:
 {% if os10_system.hostname is defined and os10_system.hostname %}
 hostname {{ os10_system.hostname }}
 {% endif %}
+{% if os10_system.hardware_forwarding_ipv6_extended_prefix is defined %}
+  {% if os10_system.hardware_forwarding_ipv6_extended_prefix is defined %}
+hardware l3 ipv6-extended-prefix {{ os10_system.hardware_forwarding_ipv6_extended_prefix }}
+  {% else %}
+no hardware l3 ipv6-extended-prefix
+  {% endif %}
+{% endif %}
 {% if os10_system.max_ra is defined %}
    {% if os10_system.max_ra %}
 ipv6 nd max-ra-interval {{ os10_system.max_ra }}

--- a/roles/os10_system/tests/main.os10.yaml
+++ b/roles/os10_system/tests/main.os10.yaml
@@ -5,6 +5,7 @@
 os10_system:
     hostname: os10
     hardware_forwarding: scaled-l3-hosts
+    hardware_forwarding_ipv6_extended_prefix: 2048
     hash_algo:
       algo:
         - name: lag


### PR DESCRIPTION
##### SUMMARY
Adding support for adding `hardware l3 ipv6-extended-prefix`. Without this, IPv6 forwarding will not work with subnet masks smaller than /64.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
os10_system

##### ADDITIONAL INFORMATION
Before this change, it wasn't possible to add `hardware l3 ipv6-extended-prefix` via Ansible. This allows you to configure the maximum number of route entries for IPv6 extended prefix route.

As an example, the following can now be used under `os10_system:`
```
hardware_forwarding_ipv6_extended_prefix: 2048
```
