### PR TITLE
adding ability to add/remove default-originate from neighbor address-family

### DIFF
--- a/roles/os10_bgp/README.md
+++ b/roles/os10_bgp/README.md
@@ -92,7 +92,7 @@ Role variables
 | ``address_family.soft_reconf`` | boolean   | Configures per neighbor soft reconfiguration | os10 |
 | ``address_family.add_path`` | string  | Configures send or receive multiple paths (value can be 'both <no of paths>', 'send <no of paths>', 'receive')| os10 |
 | ``address_family.route_map`` | list   | Configures the route-map on the BGP neighbor (see ``route_map.*``) | os10 |
-| ``address_family.default_originate`` | string: absent,present | Adds default-originate to neighbor address-family if set to present, else if set to absent, removes it. | os10 |
+| ``address_family.default_originate`` | boolean | Configures default-originate on the bgp neighbor address-family | os10 |
 | ``route_map.name`` | string  | Configures the name of the route-map for the BGP neighbor   | os10 |
 | ``route_map.filter`` | string  | Configures the filter for routing updates   | os10 |
 | ``route_map.state`` | string, choices: absent,present* | Deletes the route-map of the BGP neighbor if set to absent | os10 |

--- a/roles/os10_bgp/README.md
+++ b/roles/os10_bgp/README.md
@@ -92,7 +92,7 @@ Role variables
 | ``address_family.soft_reconf`` | boolean   | Configures per neighbor soft reconfiguration | os10 |
 | ``address_family.add_path`` | string  | Configures send or receive multiple paths (value can be 'both <no of paths>', 'send <no of paths>', 'receive')| os10 |
 | ``address_family.route_map`` | list   | Configures the route-map on the BGP neighbor (see ``route_map.*``) | os10 |
-| ``address_family.default_originate`` | string: absent,present\* | Adds default-originate to neighbor address-family if set to present, else if set to absent, removes it. | os10 |
+| ``address_family.default_originate`` | string: absent,present | Adds default-originate to neighbor address-family if set to present, else if set to absent, removes it. | os10 |
 | ``route_map.name`` | string  | Configures the name of the route-map for the BGP neighbor   | os10 |
 | ``route_map.filter`` | string  | Configures the filter for routing updates   | os10 |
 | ``route_map.state`` | string, choices: absent,present* | Deletes the route-map of the BGP neighbor if set to absent | os10 |

--- a/roles/os10_bgp/README.md
+++ b/roles/os10_bgp/README.md
@@ -92,6 +92,7 @@ Role variables
 | ``address_family.soft_reconf`` | boolean   | Configures per neighbor soft reconfiguration | os10 |
 | ``address_family.add_path`` | string  | Configures send or receive multiple paths (value can be 'both <no of paths>', 'send <no of paths>', 'receive')| os10 |
 | ``address_family.route_map`` | list   | Configures the route-map on the BGP neighbor (see ``route_map.*``) | os10 |
+| ``address_family.default_originate`` | string: absent,present\* | Adds default-originate to neighbor address-family if set to present, else if set to absent, removes it. | os10 |
 | ``route_map.name`` | string  | Configures the name of the route-map for the BGP neighbor   | os10 |
 | ``route_map.filter`` | string  | Configures the filter for routing updates   | os10 |
 | ``route_map.state`` | string, choices: absent,present* | Deletes the route-map of the BGP neighbor if set to absent | os10 |

--- a/roles/os10_bgp/templates/os10_bgp.j2
+++ b/roles/os10_bgp/templates/os10_bgp.j2
@@ -689,11 +689,13 @@ router bgp {{ bgp_vars.asn }}
                       {% endif %}
                     {% endif %}
 
-                  {% if af.default_originate is defined and af.default_originate == "present" %}
+                  {% if af.default_originate is defined %}
+                   {% if af.default_originate %}
    default-originate
-                     {% elif af.default_originate is defined and af.default_originate == "absent" %}
+                     {% else %}
    no default-originate
                       {% endif %}
+                    {% endif %}
 
                   {% endif %}
                 {% endif %}

--- a/roles/os10_bgp/templates/os10_bgp.j2
+++ b/roles/os10_bgp/templates/os10_bgp.j2
@@ -689,6 +689,11 @@ router bgp {{ bgp_vars.asn }}
                       {% endif %}
                     {% endif %}
 
+                  {% if af.default_originate is defined and af.default_originate == "present" %}
+   default-originate
+                     {% elif af.default_originate is defined and af.default_originate == "absent" %}
+   no default-originate
+                      {% endif %}
 
                   {% endif %}
                 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Adding new functionality to allow user to add `default-originate` to `neighbor -> address-family` which will propagate default route to BGP neighbor.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
os10_bgp