### PR TITLE
Add the ability to match based on as-path

### DIFF
--- a/roles/os10_route_map/README.md
+++ b/roles/os10_route_map/README.md
@@ -45,6 +45,7 @@ Role variables
 | ``route_map.match`` | list | Configures the route-map to match values from the route table (see ``match.*``) | os10 |
 | ``match.ip_type`` | string (required): ipv4,ipv6   | Configures the IPv4/IPv6 address to match    | os10 |
 | ``match.access_group`` | string     | Configures the access-group or list to match                  | os10 |
+| ``match.as_path | string | Configures the as-path to match against | dellos10 |
 | ``match.source_protocol_ebgp`` | string     | Configures the source protocol to eBGP to match       | os10 |
 | ``match.source_protocol_ibgp`` | string     | Configures the source protocol to iBGP to match       | os10 |
 | ``match.source_protocol_evpn`` | string     | Configures the source protocol to EVPN to match       | os10 |

--- a/roles/os10_route_map/README.md
+++ b/roles/os10_route_map/README.md
@@ -45,7 +45,7 @@ Role variables
 | ``route_map.match`` | list | Configures the route-map to match values from the route table (see ``match.*``) | os10 |
 | ``match.ip_type`` | string (required): ipv4,ipv6   | Configures the IPv4/IPv6 address to match    | os10 |
 | ``match.access_group`` | string     | Configures the access-group or list to match                  | os10 |
-| ``match.as_path`` | string | Configures the as-path to match against | dellos10 |
+| ``match.as_path`` | string | Configures the as-path to match against | os10 |
 | ``match.source_protocol_ebgp`` | string     | Configures the source protocol to eBGP to match       | os10 |
 | ``match.source_protocol_ibgp`` | string     | Configures the source protocol to iBGP to match       | os10 |
 | ``match.source_protocol_evpn`` | string     | Configures the source protocol to EVPN to match       | os10 |

--- a/roles/os10_route_map/README.md
+++ b/roles/os10_route_map/README.md
@@ -45,7 +45,7 @@ Role variables
 | ``route_map.match`` | list | Configures the route-map to match values from the route table (see ``match.*``) | os10 |
 | ``match.ip_type`` | string (required): ipv4,ipv6   | Configures the IPv4/IPv6 address to match    | os10 |
 | ``match.access_group`` | string     | Configures the access-group or list to match                  | os10 |
-| ``match.as_path | string | Configures the as-path to match against | dellos10 |
+| ``match.as_path`` | string | Configures the as-path to match against | dellos10 |
 | ``match.source_protocol_ebgp`` | string     | Configures the source protocol to eBGP to match       | os10 |
 | ``match.source_protocol_ibgp`` | string     | Configures the source protocol to iBGP to match       | os10 |
 | ``match.source_protocol_evpn`` | string     | Configures the source protocol to EVPN to match       | os10 |

--- a/roles/os10_route_map/templates/os10_route_map.j2
+++ b/roles/os10_route_map/templates/os10_route_map.j2
@@ -184,6 +184,13 @@ route-map {{ vars.name }} permit 10
           {% endif %}
           {% if vars.match is defined and vars.match %}
             {% for match in vars.match %}
+              {% if match.as_path is defined %}
+                {% if match.as_path %}
+ match as-path {{ match.as_path }}
+                {% else %}
+ no match as-path {{ match.as_path }}
+                {% endif %}
+              {% endif %}
               {% if match.ip_type is defined and match.ip_type %}
                 {% if match.ip_type =="ipv4" %}
                   {% set ip = "ip" %}

--- a/roles/os10_route_map/tests/main.yaml
+++ b/roles/os10_route_map/tests/main.yaml
@@ -6,6 +6,14 @@ os10_route_map:
       permit: true
       regex: www
       state: present
+    - access_list: bb
+      permit: true
+      regex: ^$
+      state: present
+    - access_list: bb
+      permit: true
+      regex: "^4200000000$"
+      state: present
   community_list:
     - type: standard
       name: qqq
@@ -33,6 +41,7 @@ os10_route_map:
          source_protocol_static: present
          source_protocol_ospf: present
          source_protocol_connected: present
+       - as_path: bb
       set:
          local_pref: 1200
          metric_type: internal

--- a/roles/os10_route_map/tests/main.yaml
+++ b/roles/os10_route_map/tests/main.yaml
@@ -6,11 +6,11 @@ os10_route_map:
       permit: true
       regex: www
       state: present
-    - access_list: bb
+    - access_list: as_path_list
       permit: true
       regex: ^$
       state: present
-    - access_list: bb
+    - access_list: as_path_list
       permit: true
       regex: "^4200000000$"
       state: present
@@ -65,5 +65,5 @@ os10_route_map:
       permit: true
       seq_num: 10
       match:
-        - as_path: bb
+        - as_path: as_path_list
       state: present

--- a/roles/os10_route_map/tests/main.yaml
+++ b/roles/os10_route_map/tests/main.yaml
@@ -41,7 +41,6 @@ os10_route_map:
          source_protocol_static: present
          source_protocol_ospf: present
          source_protocol_connected: present
-       - as_path: bb
       set:
          local_pref: 1200
          metric_type: internal
@@ -61,4 +60,10 @@ os10_route_map:
          extcomm_list:
            add: aa
            delete: aa
+      state: present
+    - name: as-path-test
+      permit: true
+      seq_num: 10
+      match:
+        - as_path: bb
       state: present


### PR DESCRIPTION
For example, we may wish to have a route map as follows

```
ip as-path access-list local_origin permit ^$
ip as-path access-list local_origin permit ^65000000$

route-map local_origin_only permit 10
 match as-path local_origin
!
```

Adding support for as-path matching allows us to manage the route map via this role and YAML with the rest of our configuration

```yaml
dellos_route_map:
  as_path:
    - access_list: local_origin
      permit: True
      regex: ^$
      state: present
    - access_list: local_origin
      permit: True
      regex: "^{{my_asn}}$"
      state: present
  route_map:
    - name: local_origin_only
      permit: True
      seq_num: 10
      match:
        - as_path: local_origin
      state: present
```
