### PR TITLE
Enable setting forward error correction for an interface

### DIFF
--- a/changelogs/fragments/forward-error-correction-feature.yaml
+++ b/changelogs/fragments/forward-error-correction-feature.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- add support for setting FEC on interfaces
+- add support for setting FEC on interfaces (https://github.com/ansible-collections/dellemc.os10/issues/92)

--- a/changelogs/fragments/forward-error-correction-feature.yaml
+++ b/changelogs/fragments/forward-error-correction-feature.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- add support for setting FEC on interfaces

--- a/roles/os10_interface/README.md
+++ b/roles/os10_interface/README.md
@@ -50,6 +50,7 @@ Role variables
 | ``flowcontrol.mode`` | string:   receive,transmit  | Configures the flowcontrol mode   | os10 |
 | ``flowcontrol.enable`` | string:   on,off  | Configures the flowcontrol mode on  | os10 |
 | ``flowcontrol.state`` | string: absent,present\* | Deletes the flowcontrol if set to absent   | os10 |
+| ``fec`` | boolean: true,false | Enables or disables Forward Error Correction | os10 |
 | ``ipv6_bgp_unnum`` | dictionary | Configures the IPv6 BGP unnum attributes (see ``ipv6_bgp_unnum.*``) below | os10 |
 | ``ipv6_bgp_unnum.state`` | string: absent,present\* | Disables auto discovery of BGP unnumbered peer if set to absent | os10 |
 | ``ipv6_bgp_unnum.peergroup_type`` | string: ebgp,ibgp | Specifies the type of template to inherit from | os10 |

--- a/roles/os10_interface/templates/os10_interface.j2
+++ b/roles/os10_interface/templates/os10_interface.j2
@@ -108,6 +108,15 @@ interface {{ interface_key }}
     {% endif %}
   {% endif %}
 
+  {% if intf_vars.fec is defined %}
+    {% if intf_vars.fec %}
+ fec on
+    {% else %}
+ fec off
+    {% endif %}
+ no fec
+  {% endif %}
+
   {% if intf_vars.mtu is defined %}
     {% if intf_vars.mtu %}
  mtu {{ intf_vars.mtu }}


### PR DESCRIPTION
This adds the ability to enable or disable FEC on interfaces managed via the `os10_interface` role