### PR TITLE
Create a transaction for the VLAN changes

### DIFF
--- a/roles/os10_vlan/templates/os10_vlan.j2
+++ b/roles/os10_vlan/templates/os10_vlan.j2
@@ -32,6 +32,7 @@ os10_vlan:
 
 #########################################}
 {% if os10_vlan is defined and os10_vlan %}
+start transaction
 {% for key,value in os10_vlan.items() %}
   {% if key == "default_vlan_id" %}
     {% if value %}
@@ -126,4 +127,5 @@ interface {{ ports.port.split() | join() }}
   {% endif %}
   {% endif %}
 {% endfor %}
+do commit
 {% endif %}


### PR DESCRIPTION
This attempts to speed up VLAN changes by changing OS10's behavior
of checking each line as it is entered, to checking the entire change
after all the changes have been entered. This hopefully will improve
execution times for switches that have large VLAN based configurations.
