### PR TITLE
Allow config backup when using the full module name

### DIFF
--- a/plugins/action/os10.py
+++ b/plugins/action/os10.py
@@ -41,7 +41,8 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'os10_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'os10_config' else False
         socket_path = None
 
         if self._play_context.connection == 'network_cli':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This fixes the issue of not being able to save config when you use the full module name i.e. `dellemc.os10.os10_config`.
This would cause `self._task.action == 'os10_config'` to always return `False`.
Now you can use 
```
- dellemc.os10.os10_config:
    backup: yes
```
and
```
  collections:
    - dellemc.os10
  os10_config:
      backup: yes
```
This is in line with https://github.com/ansible-collections/dellemc.os9/blob/main/plugins/action/os9.py#L44
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`os10.py`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
