### PR TITLE
Add support for vlt-port-channel in os10_lag

### DIFF
--- a/changelogs/fragments/108-lag-vlt-port-channel.yaml
+++ b/changelogs/fragments/108-lag-vlt-port-channel.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - os10_lag - Add support for vlt-port-channel option (https://github.com/ansible-collections/dellemc.os10/pull/108)
+  - os10_lag - Add support for vlt-port-channel option (https://github.com/ansible-collections/dellemc.os10/pull/108).

--- a/changelogs/fragments/108-lag-vlt-port-channel.yaml
+++ b/changelogs/fragments/108-lag-vlt-port-channel.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - os10_lag - Add support for vlt-port-channel option (https://github.com/ansible-collections/dellemc.os10/pull/108)

--- a/roles/os10_lag/README.md
+++ b/roles/os10_lag/README.md
@@ -27,6 +27,7 @@ Role variables
 | ``max_bundle_size`` | integer | Configures the maximum bundle size for the port channel  | os10 |
 | ``lacp_system_priority`` | integer | Configures the LACP system-priority value | os10 |
 | ``lacp_fallback_enable`` | boolean | Configures LACP fallback | os10 |
+| ``vlt_port_channel`` | integer | Configure the lag as VLT | os10 |
 | ``channel_members``  | list  | Specifies the list of port members to be associated to the port-channel (see ``channel_members.*``) | os10 |
 | ``channel_members.port`` | string  | Specifies valid interface names to be configured as port-channel members | os10 |
 | ``channel_members.mode`` | string: active,passive,on | Configures mode of channel members | os10 |

--- a/roles/os10_lag/templates/os10_lag.j2
+++ b/roles/os10_lag/templates/os10_lag.j2
@@ -49,6 +49,13 @@ interface port-channel{{ channel_id[1] }}
     {% if lag_vars.lacp_fallback_enable is defined and lag_vars.lacp_fallback_enable %}
  lacp fallback enable
     {% endif %}
+    {% if lag_vars.vlt_port_channel is defined %}
+      {% if lag_vars.vlt_port_channel %}
+ vlt-port-channel {{ lag_vars.vlt_port_channel }}
+      {% else %}
+ no vlt-port-channel
+      {% endif %}
+    {% endif %}
     {% if lag_vars.channel_members is defined %}
       {% for ports in lag_vars.channel_members %}
         {% if ports.port is defined and ports.port %}


### PR DESCRIPTION
##### SUMMARY
When you want a redundant LACP lag to a end-device connected to both switches in a VLT domain.
https://www.dell.com/support/kbdoc/en-us/000102901/dell-emc-networking-os10-how-to-set-up-virtual-link-trunking-vlt?lang=en (See "Configure a LAG for a connected end device")

##### ISSUE TYPE
- Feature Pull Request
