### PR TITLE
Fix indentation of negotiation commands

### DIFF
--- a/changelogs/fragments/fix-interface-negotiation.yaml
+++ b/changelogs/fragments/fix-interface-negotiation.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix indentation of interface negotiation introduced by (https://github.com/ansible-collections/dellemc.os10/pull/77).

--- a/roles/os10_interface/templates/os10_interface.j2
+++ b/roles/os10_interface/templates/os10_interface.j2
@@ -134,12 +134,12 @@ interface {{ interface_key }}
   {% endif %}
   {% if intf_vars.auto_neg is defined %}
     {% if intf_vars.auto_neg %}
-negotiation on
+ negotiation on
     {% else %}
-negotiation off
+ negotiation off
     {% endif %}
   {% else %}
-no negotiation
+ no negotiation
   {% endif %}
   {% if intf_vars.ip_type_dynamic is defined %}
     {% if intf_vars.ip_type_dynamic %} 


### PR DESCRIPTION
##### SUMMARY
Missing prefixed whitespace for a command that should run in a context and not in top-level context.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os10_interface

##### ADDITIONAL INFORMATION
Without this change the interface role fails no matter the mode you set autoneg in. Prefixing these commands with a whitespace that should run in a sub-context makes it work.

Fixes problem introduced in #77 
