### PR TITLE
Replace bool auto_neg with 4-option negotiation

### DIFF
--- a/roles/os10_interface/README.md
+++ b/roles/os10_interface/README.md
@@ -55,7 +55,7 @@ Role variables
 | ``ipv6_bgp_unnum.state`` | string: absent,present\* | Disables auto discovery of BGP unnumbered peer if set to absent | os10 |
 | ``ipv6_bgp_unnum.peergroup_type`` | string: ebgp,ibgp | Specifies the type of template to inherit from | os10 |
 | ``stp_rpvst_default_behaviour`` | boolean: false,true     | Configures RPVST default behaviour of BPDU's when set to True which is default | os10 |
-| ``auto_neg`` | boolean: false,true\* | Configures whether interface speed negotiation is enabled or not | os10 |
+| ``negotiation`` | string: auto,on,off | Configures whether interface speed negotiation is set to on, off or auto | os10 |
 
 > **NOTE**: Asterisk (*) denotes the default value if none is specified.
 

--- a/roles/os10_interface/templates/os10_interface.j2
+++ b/roles/os10_interface/templates/os10_interface.j2
@@ -132,14 +132,14 @@ interface {{ interface_key }}
  no speed
     {% endif %}
   {% endif %}
-  {% if intf_vars.auto_neg is defined %}
-    {% if intf_vars.auto_neg %}
+  {% if intf_vars.negotiation is defined %}
+    {% if intf_vars.negotiation == "on" %}
  negotiation on
-    {% else %}
+    {% elif intf_vars.negotiation == "off" %}
  negotiation off
+    {% else %}
+ negotiation auto
     {% endif %}
-  {% else %}
- no negotiation
   {% endif %}
   {% if intf_vars.ip_type_dynamic is defined %}
     {% if intf_vars.ip_type_dynamic %} 


### PR DESCRIPTION
Replace bool auto_neg that always generates `no negotiation` lines when
undefined - causing errors on S4148 running OS10 ver 10.5.3.4 as
described in issue #133

Add negotiation parameter with "on", "off" or "auto" values that
translate to
```
sw01(conf-if-eth1/1/1)# negotiation ?
  auto  Automatic settings(default)
  on    Negotiation is on
  off   Negotiation is off
```

Undefined negotiation parameter should not generate any output to the
resulting config to avoid failing on virtual interfaces (vlans,
loopbackes, ...) that do not support negotiation

```
sw01(config)# interface vlan 100
sw01(conf-if-vl-100)# negotiation auto
% Error: Unrecognized command.
sw01(conf-if-vl-100)# no negotiation
% Error: Unrecognized command.
```

##### SUMMARY
Correct interface negotiation settings to be able to set all possible values or not setting any
value at all (for interfaces that do not support it).

Fixes #133.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
role os10_interface

##### ADDITIONAL INFORMATION
