### PR TITLE
fix orders, add 3 states on mgmtif, add os10_cfg_deploy parameter 

### DIFF
--- a/roles/os10_aaa/tasks/main.yml
+++ b/roles/os10_aaa/tasks/main.yml
@@ -12,6 +12,6 @@
  - name: "Provisioning AAA configuration for os10"
    os10_config:
       src: os10_aaa.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") 
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")  and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_acl/tasks/main.yml
+++ b/roles/os10_acl/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning ACL configuration for os10"
    os10_config:
       src: os10_acl.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_bfd/tasks/main.yml
+++ b/roles/os10_bfd/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning bfd global configuration for os10"
    os10_config:
       src: os10_bfd.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_bgp/tasks/main.yml
+++ b/roles/os10_bgp/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning BGP configuration for os10"
    os10_config:
       src: os10_bgp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_copy_config/tasks/main.yml
+++ b/roles/os10_copy_config/tasks/main.yml
@@ -3,5 +3,5 @@
  - name: "Merge the config file to running configuration for OS10"
    os10_config:
       src: "{{ hostname }}.j2"
-   when: (ansible_network_os is defined and ansible_network_os== "dellemc.os10.os10") 
+   when: (ansible_network_os is defined and ansible_network_os== "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10

--- a/roles/os10_dns/tasks/main.yml
+++ b/roles/os10_dns/tasks/main.yml
@@ -12,6 +12,6 @@
  - name: "Provisioning DNS configuration for os10"
    os10_config:
       src: os10_dns.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_ecmp/tasks/main.yml
+++ b/roles/os10_ecmp/tasks/main.yml
@@ -12,6 +12,6 @@
  - name: "Provisioning ECMP configuration for os10"
    os10_config:
       src: os10_ecmp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_flow_monitor/tasks/main.yml
+++ b/roles/os10_flow_monitor/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning Flow monitor configuration for os10"
    os10_config:
       src: os10_flow_monitor.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_interface/tasks/main.yml
+++ b/roles/os10_interface/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning interface configuration for os10"
    os10_config:
       src: os10_interface.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_lag/tasks/main.yml
+++ b/roles/os10_lag/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning LAG configuration for os10"
    os10_config:
       src: os10_lag.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_lldp/tasks/main.yml
+++ b/roles/os10_lldp/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning LLDP configuration for os10"
    os10_config:
       src: os10_lldp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_logging/tasks/main.yml
+++ b/roles/os10_logging/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning logging configuration for os10"
    os10_config:
       src: os10_logging.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_ntp/tasks/main.yml
+++ b/roles/os10_ntp/tasks/main.yml
@@ -11,7 +11,7 @@
  - name: "Provisioning NTP configuration for os10"
    os10_config:
       src: os10_ntp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output
 
@@ -36,6 +36,7 @@
    when: >
       (ansible_network_os is defined and 
       ansible_network_os == "dellemc.os10.os10" and 
+      ((os10_cfg_deploy | default('True')) | bool) and
       os10_ntp.vrf is defined and 
       os10_ntp.vrf)
 #   notify: save config os10

--- a/roles/os10_prefix_list/tasks/main.yml
+++ b/roles/os10_prefix_list/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning prefix list configuration for os10"
    os10_config:
       src: os10_prefix_list.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_qos/tasks/main.yml
+++ b/roles/os10_qos/tasks/main.yml
@@ -1,12 +1,5 @@
 ---
 # tasks file for Dellos10
- - name: "Provisioning Qos configuration for os10"
-   os10_config:
-      src: os10_qos.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
-#   notify: save config os10
-   register: output
-
  - name: "Generating Qos configuration for os10"
    template:
       src: os10_qos.j2
@@ -14,3 +7,10 @@
    when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_generate | default('False')) | bool)
 #   notify: save config os10
    register: generate_output
+
+ - name: "Provisioning Qos configuration for os10"
+   os10_config:
+      src: os10_qos.j2
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
+#   notify: save config os10
+   register: output

--- a/roles/os10_raguard/tasks/main.yml
+++ b/roles/os10_raguard/tasks/main.yml
@@ -12,6 +12,6 @@
  - name: "Provisioning IPv6 RA Guard configuration for os10"
    os10_config:
       src: os10_raguard.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_route_map/tasks/main.yml
+++ b/roles/os10_route_map/tasks/main.yml
@@ -1,12 +1,5 @@
 ---
 # tasks file for os10
- - name: "Provisioning route-map configuration for os10"
-   os10_config:
-      src: os10_route_map.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
-#   notify: save config os10
-   register: output
-
  - name: "Generating route map configuration for os10"
    template:
       src: os10_route_map.j2
@@ -14,3 +7,10 @@
    when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_generate | default('False')) | bool)
 #   notify: save config os10
    register: generate_output
+
+ - name: "Provisioning route-map configuration for os10"
+   os10_config:
+      src: os10_route_map.j2
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
+#   notify: save config os10
+   register: output

--- a/roles/os10_snmp/tasks/main.yml
+++ b/roles/os10_snmp/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning SNMP configuration for os10"
    os10_config:
       src: os10_snmp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_system/tasks/main.yml
+++ b/roles/os10_system/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning system configuration for os10"
    os10_config:
       src: os10_system.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_uplink/tasks/main.yml
+++ b/roles/os10_uplink/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning uplink configuration for os10"
    os10_config:
       src: os10_uplink.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_users/tasks/main.yml
+++ b/roles/os10_users/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning users configuration for os10"
    os10_config:
       src: os10_users.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_vlan/tasks/main.yml
+++ b/roles/os10_vlan/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning VLAN configuration for os10"
    os10_config:
       src: os10_vlan.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_vlt/tasks/main.yml
+++ b/roles/os10_vlt/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning VLT configuration for os10"
    os10_config:
       src: os10_vlt.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_vrf/README.md
+++ b/roles/os10_vrf/README.md
@@ -38,6 +38,7 @@ Role variables
 | ``ipv6_route_export.route_map_value``  | string    | Configures the route-map value | os10 |
 | ``ipv6_route_import.state``  | string    | Deletes the IP config if set to absent | os10 |
 | ``vrfdetails.map_ip_interface``  | list        | Specifies a list of valid interface names | os10 |
+| ``vrfdetails.mgmtif``  | bool        | Configure Managment Interface on the vrf | os10 |
 | ``map_ip_interface.intf_id``  | string    | Specifies a valid interface name | os10 |
 | ``map_ip_interface.state``  | string    | Deletes VRF association in the interface if set to absent | os10 |
 | ``upd_src_ip_loopback_id``  | string    |  Configures the source IP for any leaked route in VRF from the provided loopback ID, delete if empty string| os10 |
@@ -112,6 +113,7 @@ When `os10_cfg_generate` is set to true, the variable generates the configuratio
             map_ip_interface:
              - intf_id : "loopback11"
                state   : "present"
+            mgmtif: true
 
     os_vrf_upd_src_loopback:
         vrfdetails:

--- a/roles/os10_vrf/tasks/main.yml
+++ b/roles/os10_vrf/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning VRF configuration for os10"
    os10_config:
       src: os10_vrf.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_vrf/templates/os10_vrf.j2
+++ b/roles/os10_vrf/templates/os10_vrf.j2
@@ -94,6 +94,11 @@ ip vrf {{ vrf.vrf_name }}
               {% endif %}
             {% endif %}
           {% endif %}
+          {% if vrf.mgmtif is defined and vrf.mgmtif %}
+  interface management
+          {% else %}
+  no interface management
+          {% endif %}          
           {% if vrf.map_ip_interface is defined and vrf.map_ip_interface %}
  exit
             {% for map_ip_interface in vrf.map_ip_interface %}

--- a/roles/os10_vrf/templates/os10_vrf.j2
+++ b/roles/os10_vrf/templates/os10_vrf.j2
@@ -96,7 +96,7 @@ ip vrf {{ vrf.vrf_name }}
           {% endif %}
           {% if vrf.mgmtif is defined and vrf.mgmtif %}
   interface management
-          {% else %}
+          {% elif vrf.mgmtif is defined and not vrf.mgmtif %}
   no interface management
           {% endif %}          
           {% if vrf.map_ip_interface is defined and vrf.map_ip_interface %}

--- a/roles/os10_vrrp/tasks/main.yml
+++ b/roles/os10_vrrp/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning VRRP configuration for os10"
    os10_config:
       src: os10_vrrp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_vxlan/tasks/main.yml
+++ b/roles/os10_vxlan/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning vxlan configuration for os10"
    os10_config:
       src: os10_vxlan.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output

--- a/roles/os10_xstp/tasks/main.yml
+++ b/roles/os10_xstp/tasks/main.yml
@@ -11,6 +11,6 @@
  - name: "Provisioning xSTP configuration for os10"
    os10_config:
       src: os10_xstp.j2
-   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10")
+   when: (ansible_network_os is defined and ansible_network_os == "dellemc.os10.os10") and ((os10_cfg_deploy | default('True')) | bool)
 #   notify: save config os10
    register: output


### PR DESCRIPTION
##### SUMMARY
- fix orders in the roles: FIRST create configs, THEN deploy it
- add os10_cfg_deploy parameter, set in on false, nothing will deploy. if config on true and deploy on false, just the config will be created.
- add 3. state on mgmt interface