### PR TITLE
dellemc.OS10 version 1.2.0 has an old netcommon version as a dependency #147

### DIFF
--- a/changelogs/CHANGELOG.rst
+++ b/changelogs/CHANGELOG.rst
@@ -4,6 +4,15 @@ Ansible Network Collection for Dell EMC SmartFabric OS10 Release Notes
 
 .. contents:: Topics
 
+v1.2.4
+======
+
+Bugfixes
+--------
+
+- Fixed old netcommon depedency version(2.6.1) to ansible.netcommon 4.1.0 (https://github.com/ansible-collections/dellemc.os10/issues/147)
+
+
 v1.2.3
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -194,4 +194,3 @@ releases:
 
         that have been added after the release of ``dellemc.os10`` 1.2.3.'
     release_date: '2024-01-12'
-

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -184,3 +184,14 @@ releases:
 
         that have been added after the release of ``dellemc.os10`` 1.2.2.'
     release_date: '2023-11-09'
+  1.2.4:
+    changes:
+      bugfixes:
+      - Fixed old netcommon depedency version(2.6.1) to ansible.netcommon version 4.1.0 (https://github.com/ansible-collections/dellemc.os10/issues/147)
+      release_summary: 'This is the bug fix of the ``dellemc.os10`` collection.
+
+        This changelog contains all changes to the modules in this collection
+
+        that have been added after the release of ``dellemc.os10`` 1.2.3.'
+    release_date: '2024-01-12'
+

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@ authors:
 - Shreeja R <Shreeja_R@Dell.com>
 - Prasada Reddy <Prasada_Reddy@Dell.com>
 dependencies:
-  ansible.netcommon: '>=2.0.0,<3.0.0'
+  ansible.netcommon: '>=2.0.0,<5.0.0'
 description: Ansible Network Collection for Dell EMC SmartFabric OS10
 license_file: LICENSE
 name: os10


### PR DESCRIPTION
v1.2.4
======

Bugfixes
--------

- Fixed old netcommon depedency version(2.6.1) to ansible.netcommon 4.1.0 (https://github.com/ansible-collections/dellemc.os10/issues/147)
