### PR TITLE
Remove ansible.netcommon <5.0.0 dependency to permit install of the newest releases

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@ authors:
 - Shreeja R <Shreeja_R@Dell.com>
 - Prasada Reddy <Prasada_Reddy@Dell.com>
 dependencies:
-  ansible.netcommon: '>=2.0.0,<5.0.0'
+  ansible.netcommon: '>=2.0.0'
 description: Ansible Network Collection for Dell EMC SmartFabric OS10
 license_file: LICENSE
 name: os10


### PR DESCRIPTION
##### SUMMARY
Removed the upper offset of ansible.netcommon collection dependency to permit install of the newest releases
At this time the collection version is 6.1.1, so with the dependency <5.0.0 it's impossible to install with newer collections that have ansible.netcommon as dependency

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
All components

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
