### PR TITLE
Ansible certification for 2.15 and 2.16

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -8,11 +8,8 @@ jobs:
     strategy:
       matrix:
         ansible:
-        - stable-2.10
-        - stable-2.12
-        - stable-2.13
-        - stable-2.14
         - stable-2.15
+        - stable-2.16
     runs-on: ubuntu-latest
     steps:
 
@@ -21,10 +18,10 @@ jobs:
         with:
           path: ansible_collections/dellemc/os10
 
-      - name: Set up Python 3.9
+      - name: Set up Python "3.10"
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -33,4 +30,4 @@ jobs:
         run: ansible-galaxy collection install ansible.netcommon -p ../../
 
       - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color --python 3.9
+        run: ansible-test sanity --docker -v --color --python "3.10"

--- a/changelogs/CHANGELOG.rst
+++ b/changelogs/CHANGELOG.rst
@@ -4,6 +4,18 @@ Ansible Network Collection for Dell EMC SmartFabric OS10 Release Notes
 
 .. contents:: Topics
 
+v1.2.5
+======
+
+Release Summary
+---------------
+
+This is to Update our Certified Ansible Collection as per the redhat
+This is for OS10 collections for Ansible core versions 2.15 and 2.16
+This is the minor release of the ``dellemc.os10`` collection.
+This changelog contains all changes to the modules in this collection
+This have been added after the release of ``dellemc.os10`` 1.2.4.
+
 v1.2.4
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -194,3 +194,11 @@ releases:
 
         that have been added after the release of ``dellemc.os10`` 1.2.3.'
     release_date: '2024-01-12'
+  1.2.5:
+    changes:
+      release_summary: 'This is to Update our Certified Ansible Collection as per the redhat
+      This is for OS10 collections for Ansible core versions 2.15 and 2.16
+      This is the minor release of the ``dellemc.os10`` collection.
+      This changelog contains all changes to the modules in this collection
+      This have been added after the release of ``dellemc.os10`` 1.2.4.'
+    release_date: '2024-05-16'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: os10
 namespace: dellemc
 readme: README.md
 tags: [dell, dellemc, os10, emc, networking]
-version: 1.2.4
+version: 1.2.5
 repository: https://github.com/ansible-collections/dellemc.os10
 documentation: https://github.com/ansible-collections/dellemc.os10/tree/master/docs
 homepage: https://github.com/ansible-collections/dellemc.os10

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.15.0'
 plugin_routing:
   action:
     os10_config:


### PR DESCRIPTION
v1.2.5
======

Release Summary
---------------

This is to Update our Certified Ansible Collection as per the redhat
This is for OS10 collections for Ansible core versions 2.15 and 2.16
This is the minor release of the ``dellemc.os10`` collection.
This changelog contains all changes to the modules in this collection
This have been added after the release of ``dellemc.os10`` 1.2.4.