### PR TITLE
Remove ansible.netcommon <5.0.0 dependency to permit install of the newest releases #168

### DIFF
--- a/changelogs/CHANGELOG.rst
+++ b/changelogs/CHANGELOG.rst
@@ -4,6 +4,14 @@ Ansible Network Collection for Dell EMC SmartFabric OS10 Release Notes
 
 .. contents:: Topics
 
+v1.2.6
+======
+
+Bugfixes
+--------
+
+- Remove ansible.netcommon <5.0.0 dependency to permit install of the newest releases (https://github.com/ansible-collections/dellemc.os10/issues/168)
+
 v1.2.5
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -202,3 +202,13 @@ releases:
       This changelog contains all changes to the modules in this collection
       This have been added after the release of ``dellemc.os10`` 1.2.4.'
     release_date: '2024-05-16'
+  1.2.6:
+    changes:
+      bugfixes:
+      - Remove ansible.netcommon <5.0.0 dependency to permit install of the newest releases (https://github.com/ansible-collections/dellemc.os10/issues/168)
+      release_summary: 'This is the bug fix of the ``dellemc.os10`` collection.
+
+        This changelog contains all changes to the modules in this collection
+
+        that have been added after the release of ``dellemc.os10`` 1.2.5.'
+    release_date: '2024-07-11'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,14 +4,14 @@ authors:
 - Shreeja R <Shreeja_R@Dell.com>
 - Prasada Reddy <Prasada_Reddy@Dell.com>
 dependencies:
-  ansible.netcommon: '>=2.0.0,<5.0.0'
+  ansible.netcommon: '>=2.0.0'
 description: Ansible Network Collection for Dell EMC SmartFabric OS10
 license_file: LICENSE
 name: os10
 namespace: dellemc
 readme: README.md
 tags: [dell, dellemc, os10, emc, networking]
-version: 1.2.5
+version: 1.2.6
 repository: https://github.com/ansible-collections/dellemc.os10
 documentation: https://github.com/ansible-collections/dellemc.os10/tree/master/docs
 homepage: https://github.com/ansible-collections/dellemc.os10


### PR DESCRIPTION
v1.2.6
======

Bugfixes
--------

- Remove ansible.netcommon <5.0.0 dependency to permit install of the newest releases (https://github.com/ansible-collections/dellemc.os10/issues/168)