### PR TITLE
fix for os10_bgp supported documented flag summary_only

### DIFF
--- a/changelogs/CHANGELOG.rst
+++ b/changelogs/CHANGELOG.rst
@@ -4,6 +4,15 @@ Ansible Network Collection for Dell EMC SmartFabric OS10 Release Notes
 
 .. contents:: Topics
 
+v1.2.7
+======
+
+Bugfixes
+--------
+
+- Fixed os10_bgp supported documented flag summary_only in the template (https://github.com/ansible-collections/dellemc.os10/issues/167)
+
+
 v1.2.6
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -212,3 +212,13 @@ releases:
 
         that have been added after the release of ``dellemc.os10`` 1.2.5.'
     release_date: '2024-07-11'
+  1.2.7:
+    changes:
+      bugfixes:
+      - Fixed os10_bgp supported documented flag summary_only in the template (https://github.com/ansible-collections/dellemc.os10/issues/167)
+      release_summary: 'This is the bug fix of the ``dellemc.os10`` collection.
+
+        This changelog contains all changes to the modules in this collection
+
+        that have been added after the release of ``dellemc.os10`` 1.2.6.'
+    release_date: '2025-01-06'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: os10
 namespace: dellemc
 readme: README.md
 tags: [dell, dellemc, os10, emc, networking]
-version: 1.2.6
+version: 1.2.7
 repository: https://github.com/ansible-collections/dellemc.os10
 documentation: https://github.com/ansible-collections/dellemc.os10/tree/master/docs
 homepage: https://github.com/ansible-collections/dellemc.os10

--- a/roles/os10_bgp/templates/os10_bgp.j2
+++ b/roles/os10_bgp/templates/os10_bgp.j2
@@ -745,7 +745,7 @@ os10_bgp:
               {% if addr.attr_map is defined and addr.attr_map %}
                 {% set aggr_str = aggr_str ~ " attribute-map " ~ addr.attr_map %}
               {% endif %}
-              {% if addr.summary is defined and addr.summary %}
+              {% if addr.summary_only is defined and addr.summary_only %}
                 {% set aggr_str = aggr_str ~ " summary-only" %}
               {% endif %}
               {% if addr.suppress_map is defined and addr.suppress_map %}


### PR DESCRIPTION
      - Fixed os10_bgp supported documented flag summary_only in the template (https://github.com/ansible-collections/dellemc.os10/issues/167)
      release_summary: 'This is the bug fix of the ``dellemc.os10`` collection.

        This changelog contains all changes to the modules in this collection

        that have been added after the release of ``dellemc.os10`` 1.2.6.'
    release_date: '2025-01-06'
